### PR TITLE
added example using getContentItem, dependant on v 1.1.0 of the sdk 

### DIFF
--- a/example/react/package.json
+++ b/example/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@agility/app-sdk": "^1.0.0",
+    "@agility/app-sdk": "^1.1.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",

--- a/example/react/src/Components/BasicCustomField.jsx
+++ b/example/react/src/Components/BasicCustomField.jsx
@@ -18,7 +18,7 @@ export default function BasicCustomField() {
 
 	useEffect(() => {
 		agilityAppSDK.initializeField({ containerRef }).then((fieldSDK) => {
-
+			
 			//set the SDK that we can use later...
 			setSDK(fieldSDK);
 
@@ -49,7 +49,10 @@ export default function BasicCustomField() {
 		sdk.updateFieldValue({ fieldValue: newVal });
 	}
 
-	const openCustomFlyout = () => {
+	const openCustomFlyout = async () => {
+
+		//retrieve the latest values of the content item - so we can pass to our flyout
+		const contentItem = await sdk.getContentItem();
 
 		sdk.openFlyout({
 			title: 'Flyout Title',
@@ -69,7 +72,8 @@ export default function BasicCustomField() {
 
 			},
 			params: {
-				key: 'value'
+				key: 'value', //example
+				contentItem: contentItem
 			}
 		})
 	}

--- a/example/react/src/Components/Flyout.jsx
+++ b/example/react/src/Components/Flyout.jsx
@@ -14,6 +14,7 @@ function Flyout({ appConfig }) {
 
 	useEffect(() => {
 		agilityAppSDK.initializeFlyout({ containerRef }).then((flyoutSDK) => {
+			
 			setSDK(flyoutSDK);
 			setFlyout(flyoutSDK.flyout);
 
@@ -34,6 +35,10 @@ function Flyout({ appConfig }) {
 		sdk.closeFlyout({})
 	}
 
+	if(sdk && sdk.flyout) {
+		//access the parameters passed to your flyout
+		console.log('flyout params', sdk.flyout.params)
+	}
 
 	return (
 		<div className="flyout-panel" ref={containerRef}>


### PR DESCRIPTION
Implemented example of `fieldSDK.getContentItem` in the basic react app. This requires version `1.1.0` of the `@agility/app-sdk` to be published before. To test locally, use `npm link`.