### PR TITLE
removed replaceAll

### DIFF
--- a/translator/pages/api/detect.ts
+++ b/translator/pages/api/detect.ts
@@ -14,7 +14,7 @@ export default async function detect(req: NextApiRequest, res: NextApiResponse<D
 	const projectId = req.body.configValues.google_projectID
 	const client_email = req.body.configValues.google_client_email
 	let private_key:string = req.body.configValues.google_private_key
-	private_key = private_key.replaceAll("\\n", "\n")
+	private_key = private_key.replace(/\\n/, "\n")
 
 	const translate = new Translate({
 		projectId,


### PR DESCRIPTION
string.replaceAll doesn't work on nodejs 14, which is what vercel is running for our serverless functions.  Needed to use a regex.